### PR TITLE
Custom client build tools

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,6 +4,7 @@
 
 const { mkdirSync } = require('fs');
 const path = require('path');
+const url = require('url');
 
 const changed = require('gulp-changed');
 const commander = require('commander');
@@ -218,6 +219,24 @@ gulp.task(
   })
 );
 
+gulp.task('build-html', () => {
+  const clientIdRequiredMsg =
+    'You must configure an OAuth client ID with the "OAUTH_CLIENT_ID" env var';
+  const apiUrl = process.env.API_URL || 'https://hypothes.is/api/';
+  const config = {
+    apiUrl,
+    authDomain: url.parse(apiUrl).hostname,
+
+    oauthClientId: process.env.OAUTH_CLIENT_ID || clientIdRequiredMsg,
+  };
+  const htmlSafeJsonConfig = JSON.stringify(config).replace(/</g, '\\u003c');
+  return gulp
+    .src('src/sidebar/app.html')
+    .pipe(replace('__CONFIG__', htmlSafeJsonConfig))
+    .pipe(rename('app.html'))
+    .pipe(gulp.dest('./build'));
+});
+
 const MANIFEST_SOURCE_FILES =
   'build/@(fonts|images|scripts|styles)/*.@(js|css|woff|jpg|png|svg)';
 
@@ -244,7 +263,7 @@ function generateBootScript(manifest, { usingDevServer = false } = {}) {
   } else {
     defaultAssetRoot = '{current_scheme}://{current_host}:3001/hypothesis';
   }
-  defaultAssetRoot = `${defaultAssetRoot}/${version}/`;
+  defaultAssetRoot = `${defaultAssetRoot}/${version}/build/`;
 
   if (isFirstBuild) {
     log(`Sidebar app URL: ${defaultSidebarAppUrl}`);
@@ -309,6 +328,7 @@ const buildAssets = gulp.parallel(
   'build-js',
   'build-css',
   'build-fonts',
+  'build-html',
   'build-images'
 );
 gulp.task('build', gulp.series(buildAssets, generateManifest));

--- a/scripts/build-app
+++ b/scripts/build-app
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# Create a production build of the client with a given OAuth client ID
+#
+# Usage:
+#
+# ./build <oauth_client_id> [<api_url>]
+#
+# oauth_client_id - The OAuth client ID registered with the "h" service.
+# api_url - The root URL of the h service's REST API. Must have trailing
+#           slash (eg. https://hypothes.is/api/)
+#
+# After running this script, you will need to upload the contents of the "build"
+# dir to the location that the client will be served from.
+
+set -eu
+
+export NODE_ENV=production
+export OAUTH_CLIENT_ID=$1
+export API_URL=${2:-https://hypothes.is/api/}
+
+# Remove any outputs from previous builds.
+rm -rf build/
+
+gulp build

--- a/src/boot/boot.js
+++ b/src/boot/boot.js
@@ -21,7 +21,7 @@ function injectScript(doc, src) {
 
 function injectAssets(doc, config, assets) {
   assets.forEach(function (path) {
-    const url = config.assetRoot + 'build/' + config.manifest[path];
+    const url = config.assetRoot + config.manifest[path];
     if (url.match(/\.css/)) {
       injectStylesheet(doc, url);
     } else {
@@ -63,7 +63,7 @@ function bootHypothesisClient(doc, config) {
   // annotation interactions.
   const clientUrl = doc.createElement('link');
   clientUrl.rel = 'hypothesis-client';
-  clientUrl.href = config.assetRoot + 'build/boot.js';
+  clientUrl.href = config.assetRoot + 'boot.js';
   clientUrl.type = 'application/annotator+javascript';
   doc.head.appendChild(clientUrl);
 

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -16,10 +16,40 @@ import processUrlTemplate from './url-template';
 
 const settings = jsonConfigsFrom(document);
 
+// Use the asset root and sidebar app locations specified in the host page,
+// if present. This is used by the Hypothesis browser extensions to make the
+// boot script load assets bundled with the extension.
+let assetRoot;
+if (settings.assetRoot) {
+  // The `assetRoot` setting is assumed to point at the root of the contents of
+  // the npm package.
+  assetRoot = settings.assetRoot + 'build/';
+}
+let sidebarAppUrl = settings.sidebarAppUrl;
+
+// Otherwise, try to determine the default root URL for assets and the sidebar
+// application from the location where the boot script is hosted.
+try {
+  let scriptUrl = new URL(document.currentScript.src);
+
+  // We only use the bundled sidebar HTML and assets if the boot script has
+  // its original name. If the `<script>` tag references a custom name
+  // (eg. as in "https://hypothes.is/embed.js") then we skip this and fall
+  // back to the URLs embedded in the boot script.
+  if (scriptUrl.pathname.endsWith('/boot.js')) {
+    assetRoot = assetRoot || new URL('./', scriptUrl).href;
+    sidebarAppUrl = sidebarAppUrl || new URL('app.html', scriptUrl);
+  }
+} catch (e) {
+  // IE does not support `document.currentScript` or the URL constructor.
+}
+
+// Otherwise, fall back to hardcoded default URLs.
+assetRoot = processUrlTemplate(assetRoot || '__ASSET_ROOT__');
+sidebarAppUrl = processUrlTemplate(sidebarAppUrl || '__SIDEBAR_APP_URL__');
+
 boot(document, {
-  assetRoot: processUrlTemplate(settings.assetRoot || '__ASSET_ROOT__'),
+  assetRoot,
   manifest: __MANIFEST__,
-  sidebarAppUrl: processUrlTemplate(
-    settings.sidebarAppUrl || '__SIDEBAR_APP_URL__'
-  ),
+  sidebarAppUrl,
 });

--- a/src/boot/index.js
+++ b/src/boot/index.js
@@ -38,7 +38,7 @@ try {
   // back to the URLs embedded in the boot script.
   if (scriptUrl.pathname.endsWith('/boot.js')) {
     assetRoot = assetRoot || new URL('./', scriptUrl).href;
-    sidebarAppUrl = sidebarAppUrl || new URL('app.html', scriptUrl);
+    sidebarAppUrl = sidebarAppUrl || new URL('app.html', scriptUrl).href;
   }
 } catch (e) {
   // IE does not support `document.currentScript` or the URL constructor.

--- a/src/boot/test/boot-test.js
+++ b/src/boot/test/boot-test.js
@@ -5,7 +5,7 @@ function assetUrl(url) {
   return `https://marginal.ly/client/build/${url}`;
 }
 
-describe('bootstrap', function () {
+describe('boot/boot', function () {
   let fakePolyfills;
   let iframe;
 
@@ -60,7 +60,7 @@ describe('bootstrap', function () {
 
     boot(iframe.contentDocument, {
       sidebarAppUrl: 'https://marginal.ly/app.html',
-      assetRoot: 'https://marginal.ly/client/',
+      assetRoot: 'https://marginal.ly/client/build/',
       manifest: manifest,
     });
   }

--- a/src/sidebar/app.html
+++ b/src/sidebar/app.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <hypothesis-app></hypothesis-app>
+
+    <script class="js-hypothesis-config" type="application/json">
+      __CONFIG__
+    </script>
+
+    <script src="boot.js"></script>
+  </body>
+</html>
+


### PR DESCRIPTION
Applies the upstream PR hypothesis/client/pull/1137, plus an additional minor patch to get it working for our use.

This allows us to compile the client for our own server, rather than the official h instance or a local testing environment. In practice, we'll probably use it for testing the antithesis server too.